### PR TITLE
fix: Sort slice of keys from Tree

### DIFF
--- a/example-roster.toml
+++ b/example-roster.toml
@@ -8,3 +8,11 @@ members = [
 
 ["Subteam 2"]                   # Keys can have whitespace in quoted strings
 members = ["Erin", "Frank", "Grace", "Heidi"]
+
+["Subteam 3"]
+members = [
+        "Ivan",
+        "Judy",
+        "Mallory",
+        "Niaj"
+]

--- a/random-standup.go
+++ b/random-standup.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/pelletier/go-toml"
@@ -63,6 +64,11 @@ func main() {
 	fmt.Printf("# %s\n", now.Format("2006-01-02"))
 
 	subteams := roster.Keys()
+	// Tree key order is not guaranteed, so slice of keys has to be sorted
+	// by key position in TOML
+	sort.Slice(subteams, func(i, j int) bool {
+		return roster.GetPosition(subteams[i]).Line < roster.GetPosition(subteams[j]).Line
+	})
 	for i, subteam := range subteams {
 		members := roster.GetArray(subteam + ".members").([]string)
 		printShuffledList([]string(members), subteam)


### PR DESCRIPTION
The `Tree` type has no defined ordering of its branches (i.e. the keys
of the TOML), so we have to explicitly sort the slice of keys to
ensure that the ordering of (distinct from ordering within) subteams
will be consistent.

Resolves: #2