### PR TITLE
Handle case of last subteam being empty

### DIFF
--- a/random-standup.go
+++ b/random-standup.go
@@ -90,7 +90,7 @@ func main() {
 	rand.Seed(now.UnixNano())
 
 	fmt.Printf("# %s\n", now.Format("2006-01-02"))
-	fmt.Printf("%s\n", standupOrder(roster))
+	fmt.Printf("%s", standupOrder(roster))
 }
 
 // standupOrder returns the randomized standup order from a toml.Tree.

--- a/random-standup.go
+++ b/random-standup.go
@@ -131,9 +131,6 @@ func getSortedKeys(roster *toml.Tree) []string {
 // shuffled, stringified team list beginning with the team name.
 func shuffleTeam(teamMembers []string, teamName string) string {
 	list := ""
-	if len(teamMembers) == 0 {
-		return list
-	}
 	rand.Shuffle(len(teamMembers), func(i, j int) {
 		teamMembers[i], teamMembers[j] = teamMembers[j], teamMembers[i]
 	})

--- a/random-standup.go
+++ b/random-standup.go
@@ -121,7 +121,8 @@ func getSortedKeys(roster *toml.Tree) []string {
 	// Tree key order is not guaranteed, so slice of keys has to be
 	// explicitly sorted
 	sort.Slice(subteams, func(i, j int) bool {
-		return roster.GetPosition(subteams[i]).Line < roster.GetPosition(subteams[j]).Line
+		return roster.GetPosition(subteams[i]).Line <
+			roster.GetPosition(subteams[j]).Line
 	})
 	return subteams
 }

--- a/random-standup.go
+++ b/random-standup.go
@@ -96,7 +96,7 @@ func main() {
 // standupOrder returns the randomized standup order from a toml.Tree.
 func standupOrder(roster *toml.Tree) string {
 	var order string
-	subteams := getSortedKeys(roster)
+	subteams := getSortedKeysWithMembers(roster)
 	for i, subteam := range subteams {
 		members := roster.GetArray(subteam + ".members")
 		if members == nil {
@@ -105,8 +105,6 @@ func standupOrder(roster *toml.Tree) string {
 		shuffledTeam := shuffleTeam(members.([]string), subteam)
 		order += shuffledTeam
 
-		// TODO: runs on penultimate subteam if last subteam is empty
-		// Filter list of subteams for nonempty subteams?
 		if i != len(subteams)-1 {
 			order += "\n"
 		}
@@ -114,9 +112,9 @@ func standupOrder(roster *toml.Tree) string {
 	return order
 }
 
-// getSortedKeys returns a slice of keys from the TOML sorted by their position
-// in the TOML.
-func getSortedKeys(roster *toml.Tree) []string {
+// getSortedKeysWithMembers returns a slice of keys with members subkey from
+// the TOML sorted by their position in the TOML.
+func getSortedKeysWithMembers(roster *toml.Tree) []string {
 	subteams := roster.Keys()
 	// Tree key order is not guaranteed, so slice of keys has to be
 	// explicitly sorted
@@ -124,7 +122,13 @@ func getSortedKeys(roster *toml.Tree) []string {
 		return roster.GetPosition(subteams[i]).Line <
 			roster.GetPosition(subteams[j]).Line
 	})
-	return subteams
+	cleanSubteams := []string{}
+	for _, name := range subteams {
+		if roster.GetArray(name+".members") != nil {
+			cleanSubteams = append(cleanSubteams, name)
+		}
+	}
+	return cleanSubteams
 }
 
 // shuffleTeam accepts a team's member list and name and returns the

--- a/random-standup_test.go
+++ b/random-standup_test.go
@@ -30,7 +30,7 @@ func TestShuffleTeam(t *testing.T) {
 	}
 }
 
-func TestGetSortedKeys(t *testing.T) {
+func TestGetSortedKeysWithMembers(t *testing.T) {
 
 	emptySubteams, _ := toml.Load(`
 ["subteam 1"]
@@ -51,14 +51,14 @@ members = ["Alice", "Bob"]
 		want   []string
 	}{
 
-		{emptySubteams, []string{"subteam 1", "subteam-2", "subteam 3"}},
-		{mixedSubteams, []string{"subteam 1", "subteam-2", "subteam 3"}},
+		{emptySubteams, []string{}},
+		{mixedSubteams, []string{"subteam 1", "subteam-2"}},
 	}
 
 	for _, tt := range tests {
 		testname := tt.roster.String()
 		t.Run(testname, func(t *testing.T) {
-			output := getSortedKeys(tt.roster)
+			output := getSortedKeysWithMembers(tt.roster)
 			if !reflect.DeepEqual(output, tt.want) {
 				t.Errorf("got %s, want %s", output, tt.want)
 			}
@@ -88,6 +88,8 @@ members = ["Erin", "Frank", "Grace", "Heidi"]`
 ["Empty Subteam"]
 ` + "\n" + `["Subteam 2"]
 members = ["Erin", "Frank", "Grace", "Heidi"]`
+
+	onlyEmptySubteam := `["Empty Subteam"]`
 
 	var tests = []struct {
 		roster string
@@ -122,8 +124,7 @@ Heidi
 Grace
 Erin
 Frank
-
-`}, // trailing newline is workaround
+`},
 		{middleSubteamEmpty, `## Subteam-1
 Bob
 David
@@ -136,6 +137,7 @@ Grace
 Heidi
 Frank
 `},
+		{onlyEmptySubteam, ``},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Ensures that no extra newlines are printed to stdout - output will always end with exactly 1 newline.

Fixes #11